### PR TITLE
Migration to tf2. Adding static tf arcs in graph

### DIFF
--- a/bica_examples/CMakeLists.txt
+++ b/bica_examples/CMakeLists.txt
@@ -16,6 +16,10 @@ find_package(catkin REQUIRED COMPONENTS
   image_transport
   cv_bridge
   pcl_ros
+  tf2
+  tf2_ros
+  tf2_msgs
+  tf2_sensor_msgs
 )
 
 catkin_package(

--- a/bica_examples/launch/follow_ball.launch
+++ b/bica_examples/launch/follow_ball.launch
@@ -6,7 +6,7 @@
 	-->
 
 	<node pkg="bica_examples" type="ball_detector_node" name="ball_detector" output="screen"/>
-	<node pkg="bica_examples" type="ball_follower_node" name="ball_follower"/>
+	<node pkg="bica_examples" type="ball_follower_node" name="ball_follower" output="screen"/>
 
 	<node pkg="bica_graph" type="graph_master_node" name="graph_master"/>
 	<node pkg="bica" type="launcher" name="launch_ball_follower" args="ball_follower"/>

--- a/bica_examples/package.xml
+++ b/bica_examples/package.xml
@@ -20,6 +20,11 @@
   <build_depend>image_transport</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>pcl_ros</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_msgs</build_depend>
+  <build_depend>tf2_sensor_msgs</build_depend>
+
   <build_export_depend>bica</build_export_depend>
   <build_export_depend>bica_graph</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
@@ -30,6 +35,11 @@
   <build_export_depend>image_transport</build_export_depend>
   <build_export_depend>cv_bridge</build_export_depend>
   <build_export_depend>pcl_ros</build_export_depend>
+  <build_export_depend>tf2</build_export_depend>
+  <build_export_depend>tf2_ros</build_export_depend>
+  <build_export_depend>tf2_msgs</build_export_depend>
+  <build_export_depend>tf2_sensor_msgs</build_export_depend>
+
   <exec_depend>bica</exec_depend>
   <exec_depend>bica_graph</exec_depend>
   <exec_depend>roscpp</exec_depend>
@@ -40,7 +50,10 @@
   <exec_depend>image_transport</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>pcl_ros</exec_depend>
-
+  <exec_depend>tf2</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf2_msgs</exec_depend>
+  <exec_depend>tf2_sensor_msgs</exec_depend>    
   <export>
 
   </export>

--- a/bica_examples/src/graph/follow_ball/ball_detector_node.cpp
+++ b/bica_examples/src/graph/follow_ball/ball_detector_node.cpp
@@ -7,14 +7,18 @@
 #include <pcl/point_types_conversion.h>
 #include <pcl_ros/transforms.h>
 
-#include <tf/transform_broadcaster.h>
-#include <tf/transform_listener.h>
-
+#include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/PointCloud2.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2/transform_datatypes.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+
 
 #include "bica_graph/graph_client.h"
 
 #include <bica/Component.h>
+
 
 class BallDetector: public bica::Component
 {
@@ -22,26 +26,46 @@ public:
 	BallDetector()
 	: nh_(),
 		new_image_(false),
-		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>)
+		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>),
+		tfListener_(tfBuffer_)
 	{
 		cloud_sub_ = nh_.subscribe("/camera/depth/points", 1, &BallDetector::cloudCB, this);
 
 		graph_.add_node("world", "abstract");
 		graph_.add_node("leia", "robot");
 	  graph_.add_node("ball", "object");
-		graph_.add_edge("leia", "wants_see", "ball");
 
 		ROS_INFO("[%s] inited", ros::this_node::getName().c_str());
 	}
 
+	void activateCode()
+	{
+		graph_.add_edge("leia", "wants_see", "ball");
+	}
+
+	void deActivateCode()
+	{
+		graph_.remove_edge("leia", "sees", "ball");
+		graph_.remove_edge("leia", "wants_see", "ball");
+		graph_.remove_tf_edge("leia", "ball");
+	}
+
 	void cloudCB(const sensor_msgs::PointCloud2::ConstPtr& cloud_in)
 	{
+		geometry_msgs::TransformStamped transformStamped;
 		sensor_msgs::PointCloud2 cloud_in_bf;
-		pcl_ros::transformPointCloud(std::string("base_footprint"),
-			*cloud_in, cloud_in_bf, tfListener_);
 
-		pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
-		new_image_ = true;
+		try{
+			transformStamped = tfBuffer_.lookupTransform("base_footprint", cloud_in->header.frame_id, ros::Time(0));
+			tf2::doTransform(*cloud_in, cloud_in_bf, transformStamped);
+
+			pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
+			new_image_ = true;
+		}
+		catch (tf2::TransformException& ex)
+  	{
+    	ROS_WARN("%s", ex.what());
+  	}
 	}
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr filterBall()
@@ -73,7 +97,7 @@ public:
 		return pcrgb_out;
 	}
 
-	tf::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
+	tf2::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
 	{
 
 			float x, y, z;
@@ -99,9 +123,11 @@ public:
 				z = z/c;
 			}
 
-			tf::Transform transform;
-			transform.setOrigin(tf::Vector3(x, y, z));
-			transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
+			tf2::Transform transform;
+			transform.setOrigin(tf2::Vector3(x, y, z));
+			transform.setRotation(tf2::Quaternion(0.0, 0.0, 0.0, 1.0));
+
+			ROS_INFO("Detected in (%lf, %lf)", x, y);
 
 			return transform;
 	}
@@ -127,9 +153,9 @@ public:
 			}
 			else
 			{
+				graph_.add_edge("leia", "wants_see", "ball");
 				graph_.remove_edge("leia", "sees", "ball");
 				graph_.remove_tf_edge("leia", "ball");
-				graph_.add_edge("leia", "wants_see", "ball");
 			}
 		}
 	}
@@ -139,8 +165,9 @@ private:
 	ros::Subscriber cloud_sub_;
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr pcrgb_;
-	tf::TransformListener tfListener_;
-	tf::TransformBroadcaster tfBroadcaster_;
+	tf2_ros::Buffer tfBuffer_;
+  tf2_ros::TransformListener tfListener_;
+	tf2_ros::TransformBroadcaster tfBroadcaster_;
 
 	bica_graph::GraphClient graph_;
 

--- a/bica_examples/src/graph/follow_ball/ball_follower_node.cpp
+++ b/bica_examples/src/graph/follow_ball/ball_follower_node.cpp
@@ -23,12 +23,12 @@ public:
 
 		geometry_msgs::Twist cmd;
 
-		if (graph_.exist_edge("leia", "sees", "ball"))
+		if (graph_.exist_edge("leia", "sees", "ball") && graph_.exist_tf_edge("leia", "ball"))
 		{
-			tf::Transform tf_ball = graph_.get_tf_edge("leia", "ball").get();
+			tf2::Transform tf_ball = graph_.get_tf_edge("leia", "ball").get();
 
 			cmd.angular.z = std::max(std::min(atan2(tf_ball.getOrigin().y(), tf_ball.getOrigin().x()), 0.2), -0.2);
-			cmd.linear.x = std::min(tf_ball.getOrigin().length() - 0.6, 0.2);
+			cmd.linear.x = std::min(tf_ball.getOrigin().length() - 1.5, 0.2);
 
 			ROS_INFO("I see the ball in %lf %lf", tf_ball.getOrigin().x(), tf_ball.getOrigin().y());
 		}

--- a/bica_examples/src/graph/follow_ballnet/ballnet_follower_node.cpp
+++ b/bica_examples/src/graph/follow_ballnet/ballnet_follower_node.cpp
@@ -24,9 +24,9 @@ public:
 	{
 		geometry_msgs::Twist cmd;
 
-		if (graph_.exist_edge("leia", "sees", "yellow_net"))
+		if (graph_.exist_edge("leia", "sees", "yellow_net") && graph_.exist_tf_edge("leia", "yellow_net"))
 		{
-			tf::Transform tf_yellow_net = graph_.get_tf_edge("leia", "yellow_net").get();
+			tf2::Transform tf_yellow_net = graph_.get_tf_edge("leia", "yellow_net").get();
 
 			cmd.angular.z = std::max(std::min(atan2(tf_yellow_net.getOrigin().y(), tf_yellow_net.getOrigin().x()), 0.2), -0.2);
 			cmd.linear.x = std::min(tf_yellow_net.getOrigin().length() - 1.5, 0.2);
@@ -46,9 +46,9 @@ public:
 	{
 		geometry_msgs::Twist cmd;
 
-		if (graph_.exist_edge("leia", "sees", "blue_net"))
+		if (graph_.exist_edge("leia", "sees", "blue_net") && graph_.exist_tf_edge("leia", "blue_net"))
 		{
-			tf::Transform tf_blue_net = graph_.get_tf_edge("leia", "blue_net").get();
+			tf2::Transform tf_blue_net = graph_.get_tf_edge("leia", "blue_net").get();
 
 			cmd.angular.z = std::max(std::min(atan2(tf_blue_net.getOrigin().y(), tf_blue_net.getOrigin().x()), 0.2), -0.2);
 			cmd.linear.x = std::min(tf_blue_net.getOrigin().length() - 1.5, 0.2);
@@ -70,9 +70,9 @@ public:
 
 		geometry_msgs::Twist cmd;
 
-		if (graph_.exist_edge("leia", "sees", "ball"))
+		if (graph_.exist_edge("leia", "sees", "ball") && graph_.exist_tf_edge("leia", "ball"))
 		{
-			tf::Transform tf_ball_net = graph_.get_tf_edge("leia", "ball").get();
+			tf2::Transform tf_ball_net = graph_.get_tf_edge("leia", "ball").get();
 
 			cmd.angular.z = std::max(std::min(atan2(tf_ball_net.getOrigin().y(), tf_ball_net.getOrigin().x()), 0.2), -0.2);
 			cmd.linear.x = std::min(tf_ball_net.getOrigin().length() - 1.5, 0.2);

--- a/bica_examples/src/graph/follow_ballnet/yellow_net_detector_node.cpp
+++ b/bica_examples/src/graph/follow_ballnet/yellow_net_detector_node.cpp
@@ -7,10 +7,13 @@
 #include <pcl/point_types_conversion.h>
 #include <pcl_ros/transforms.h>
 
-#include <tf/transform_broadcaster.h>
-#include <tf/transform_listener.h>
-
+#include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/PointCloud2.h>
+
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2/transform_datatypes.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 
 #include "bica_graph/graph_client.h"
 
@@ -23,23 +26,43 @@ public:
 	YellowNetDetector()
 	: nh_(),
 		new_image_(false),
-		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>)
+		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>),
+		tfListener_(tfBuffer_)
 	{
 		cloud_sub_ = nh_.subscribe("/camera/depth/points", 1, &YellowNetDetector::cloudCB, this);
 
 		graph_.add_node("leia", "robot");
 	  graph_.add_node("yellow_net", "object");
+	}
+
+	void activateCode()
+	{
 		graph_.add_edge("leia", "wants_see", "yellow_net");
+	}
+
+	void deActivateCode()
+	{
+			graph_.remove_edge("leia", "wants_see", "yellow_net");
+			graph_.remove_edge("leia", "sees", "yellow_net");
+			graph_.remove_tf_edge("leia", "yellow_net");
 	}
 
 	void cloudCB(const sensor_msgs::PointCloud2::ConstPtr& cloud_in)
 	{
+		geometry_msgs::TransformStamped transformStamped;
 		sensor_msgs::PointCloud2 cloud_in_bf;
-		pcl_ros::transformPointCloud(std::string("base_footprint"),
-			*cloud_in, cloud_in_bf, tfListener_);
 
-		pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
-		new_image_ = true;
+		try{
+			transformStamped = tfBuffer_.lookupTransform("base_footprint", cloud_in->header.frame_id, ros::Time(0));
+			tf2::doTransform(*cloud_in, cloud_in_bf, transformStamped);
+
+			pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
+			new_image_ = true;
+		}
+		catch (tf2::TransformException& ex)
+		{
+			ROS_WARN("%s", ex.what());
+		}
 	}
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr filterBall()
@@ -71,7 +94,7 @@ public:
 		return pcrgb_out;
 	}
 
-	tf::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
+	tf2::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
 	{
 
 			float x, y, z;
@@ -97,9 +120,9 @@ public:
 				z = z/c;
 			}
 
-			tf::Transform transform;
-			transform.setOrigin(tf::Vector3(x, y, z));
-			transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
+			tf2::Transform transform;
+			transform.setOrigin(tf2::Vector3(x, y, z));
+			transform.setRotation(tf2::Quaternion(0.0, 0.0, 0.0, 1.0));
 
 			return transform;
 	}
@@ -124,9 +147,9 @@ public:
 			}
 			else
 			{
+				graph_.add_edge("leia", "wants_see", "yellow_net");
 				graph_.remove_edge("leia", "sees", "yellow_net");
 				graph_.remove_tf_edge("leia", "yellow_net");
-				graph_.add_edge("leia", "wants_see", "yellow_net");
 			}
 		}
 	}
@@ -136,8 +159,9 @@ private:
 	ros::Subscriber cloud_sub_;
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr pcrgb_;
-	tf::TransformListener tfListener_;
-	tf::TransformBroadcaster tfBroadcaster_;
+	tf2_ros::Buffer tfBuffer_;
+  tf2_ros::TransformListener tfListener_;
+	tf2_ros::TransformBroadcaster tfBroadcaster_;
 
 	bica_graph::GraphClient graph_;
 

--- a/bica_examples/src/graph/follow_global_ballnet/ball_global_detector_node.cpp
+++ b/bica_examples/src/graph/follow_global_ballnet/ball_global_detector_node.cpp
@@ -1,4 +1,3 @@
-
 #include <ros/ros.h>
 #include <ros/console.h>
 
@@ -7,10 +6,14 @@
 #include <pcl/point_types_conversion.h>
 #include <pcl_ros/transforms.h>
 
-#include <tf/transform_broadcaster.h>
-#include <tf/transform_listener.h>
-
+#include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/PointCloud2.h>
+
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2/transform_datatypes.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+
 
 #include "bica_graph/graph_client.h"
 
@@ -22,7 +25,8 @@ public:
 	BallDetector()
 	: nh_(),
 		new_image_(false),
-		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>)
+		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>),
+		tfListener_(tfBuffer_)
 	{
 		cloud_sub_ = nh_.subscribe("/camera/depth/points", 1, &BallDetector::cloudCB, this);
 
@@ -34,7 +38,6 @@ public:
 
 		graph_.set_tf_identity("base_footprint", "leia");
 		graph_.set_tf_identity("odom", "world");
-
 	}
 
 	void activateCode()
@@ -44,18 +47,26 @@ public:
 
 	void deActivateCode()
 	{
-		graph_.remove_edge("leia", "wants_see", "ball");
 		graph_.remove_edge("leia", "sees", "ball");
+		graph_.remove_edge("leia", "wants_see", "ball");
 	}
 
 	void cloudCB(const sensor_msgs::PointCloud2::ConstPtr& cloud_in)
 	{
+		geometry_msgs::TransformStamped transformStamped;
 		sensor_msgs::PointCloud2 cloud_in_bf;
-		pcl_ros::transformPointCloud(std::string("world"),
-			*cloud_in, cloud_in_bf, tfListener_);
 
-		pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
-		new_image_ = true;
+		try{
+			transformStamped = tfBuffer_.lookupTransform("world", cloud_in->header.frame_id, ros::Time(0));
+			tf2::doTransform(*cloud_in, cloud_in_bf, transformStamped);
+
+			pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
+			new_image_ = true;
+		}
+		catch (tf2::TransformException& ex)
+		{
+			ROS_WARN("%s", ex.what());
+		}
 	}
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr filterBall()
@@ -87,7 +98,7 @@ public:
 		return pcrgb_out;
 	}
 
-	tf::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
+	tf2::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
 	{
 
 			float x, y, z;
@@ -113,9 +124,9 @@ public:
 				z = z/c;
 			}
 
-			tf::Transform transform;
-			transform.setOrigin(tf::Vector3(x, y, z));
-			transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
+			tf2::Transform transform;
+			transform.setOrigin(tf2::Vector3(x, y, z));
+			transform.setRotation(tf2::Quaternion(0.0, 0.0, 0.0, 1.0));
 
 			return transform;
 	}
@@ -155,8 +166,9 @@ private:
 	ros::Subscriber cloud_sub_;
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr pcrgb_;
-	tf::TransformListener tfListener_;
-	tf::TransformBroadcaster tfBroadcaster_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
+	tf2_ros::TransformBroadcaster tfBroadcaster_;
 
 	bica_graph::GraphClient graph_;
 

--- a/bica_examples/src/graph/follow_global_ballnet/blue_net_global_detector_node.cpp
+++ b/bica_examples/src/graph/follow_global_ballnet/blue_net_global_detector_node.cpp
@@ -7,10 +7,13 @@
 #include <pcl/point_types_conversion.h>
 #include <pcl_ros/transforms.h>
 
-#include <tf/transform_broadcaster.h>
-#include <tf/transform_listener.h>
-
+#include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/PointCloud2.h>
+
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2/transform_datatypes.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 
 #include "bica_graph/graph_client.h"
 
@@ -22,7 +25,8 @@ public:
 	BlueNetDetector()
 	: nh_(),
 		new_image_(false),
-		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>)
+		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>),
+		tfListener_(tfBuffer_)
 	{
 		cloud_sub_ = nh_.subscribe("/camera/depth/points", 1, &BlueNetDetector::cloudCB, this);
 
@@ -47,12 +51,20 @@ public:
 
 	void cloudCB(const sensor_msgs::PointCloud2::ConstPtr& cloud_in)
 	{
+		geometry_msgs::TransformStamped transformStamped;
 		sensor_msgs::PointCloud2 cloud_in_bf;
-		pcl_ros::transformPointCloud(std::string("world"),
-			*cloud_in, cloud_in_bf, tfListener_);
 
-		pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
-		new_image_ = true;
+		try{
+			transformStamped = tfBuffer_.lookupTransform("world", cloud_in->header.frame_id, ros::Time(0));
+			tf2::doTransform(*cloud_in, cloud_in_bf, transformStamped);
+
+			pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
+			new_image_ = true;
+		}
+		catch (tf2::TransformException& ex)
+  	{
+    	ROS_WARN("%s", ex.what());
+  	}
 	}
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr filterBall()
@@ -84,7 +96,7 @@ public:
 		return pcrgb_out;
 	}
 
-	tf::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
+	tf2::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
 	{
 
 			float x, y, z;
@@ -110,9 +122,9 @@ public:
 				z = z/c;
 			}
 
-			tf::Transform transform;
-			transform.setOrigin(tf::Vector3(x, y, z));
-			transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
+			tf2::Transform transform;
+			transform.setOrigin(tf2::Vector3(x, y, z));
+			transform.setRotation(tf2::Quaternion(0.0, 0.0, 0.0, 1.0));
 
 			return transform;
 	}
@@ -149,8 +161,9 @@ private:
 	ros::Subscriber cloud_sub_;
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr pcrgb_;
-	tf::TransformListener tfListener_;
-	tf::TransformBroadcaster tfBroadcaster_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
+	tf2_ros::TransformBroadcaster tfBroadcaster_;
 
 	bica_graph::GraphClient graph_;
 

--- a/bica_examples/src/graph/follow_global_ballnet/yellow_net_global_detector_node.cpp
+++ b/bica_examples/src/graph/follow_global_ballnet/yellow_net_global_detector_node.cpp
@@ -7,10 +7,13 @@
 #include <pcl/point_types_conversion.h>
 #include <pcl_ros/transforms.h>
 
-#include <tf/transform_broadcaster.h>
-#include <tf/transform_listener.h>
-
+#include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/PointCloud2.h>
+
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2/transform_datatypes.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 
 #include "bica_graph/graph_client.h"
 
@@ -23,7 +26,8 @@ public:
 	YellowNetDetector()
 	: nh_(),
 		new_image_(false),
-		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>)
+		pcrgb_(new pcl::PointCloud<pcl::PointXYZRGB>),
+		tfListener_(tfBuffer_)
 	{
 		cloud_sub_ = nh_.subscribe("/camera/depth/points", 1, &YellowNetDetector::cloudCB, this);
 
@@ -37,7 +41,7 @@ public:
 
 	void activateCode()
 	{
-		graph_.add_edge("leia", "wants_see", "blue_net");
+		graph_.add_edge("leia", "wants_see", "yellow_net");
 	}
 
 	void deActivateCode()
@@ -48,12 +52,20 @@ public:
 
 	void cloudCB(const sensor_msgs::PointCloud2::ConstPtr& cloud_in)
 	{
+		geometry_msgs::TransformStamped transformStamped;
 		sensor_msgs::PointCloud2 cloud_in_bf;
-		pcl_ros::transformPointCloud(std::string("world"),
-			*cloud_in, cloud_in_bf, tfListener_);
 
-		pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
-		new_image_ = true;
+		try{
+			transformStamped = tfBuffer_.lookupTransform("world", cloud_in->header.frame_id, ros::Time(0));
+			tf2::doTransform(*cloud_in, cloud_in_bf, transformStamped);
+
+			pcl::fromROSMsg(cloud_in_bf, *pcrgb_);
+			new_image_ = true;
+		}
+		catch (tf2::TransformException& ex)
+		{
+			ROS_WARN("%s", ex.what());
+		}
 	}
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr filterBall()
@@ -85,7 +97,7 @@ public:
 		return pcrgb_out;
 	}
 
-	tf::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
+	tf2::Transform getTransform(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud_filtered)
 	{
 
 			float x, y, z;
@@ -111,9 +123,9 @@ public:
 				z = z/c;
 			}
 
-			tf::Transform transform;
-			transform.setOrigin(tf::Vector3(x, y, z));
-			transform.setRotation(tf::Quaternion(0.0, 0.0, 0.0, 1.0));
+			tf2::Transform transform;
+			transform.setOrigin(tf2::Vector3(x, y, z));
+			transform.setRotation(tf2::Quaternion(0.0, 0.0, 0.0, 1.0));
 
 			return transform;
 	}
@@ -151,8 +163,10 @@ private:
 	ros::Subscriber cloud_sub_;
 
 	pcl::PointCloud<pcl::PointXYZRGB>::Ptr pcrgb_;
-	tf::TransformListener tfListener_;
-	tf::TransformBroadcaster tfBroadcaster_;
+	tf2_ros::Buffer tfBuffer_;
+	tf2_ros::TransformListener tfListener_;
+	tf2_ros::TransformBroadcaster tfBroadcaster_;
+
 
 	bica_graph::GraphClient graph_;
 

--- a/bica_examples/src/graph/graph_client_A_node.cpp
+++ b/bica_examples/src/graph/graph_client_A_node.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[])
     loop_rate.sleep();
   }
 
-  tf::Transform tf_r2l(tf::Quaternion(0, 0, 0, 1), tf::Vector3(3, 0, 0));
+  tf2::Transform tf_r2l(tf2::Quaternion(0, 0, 0, 1), tf2::Vector3(3, 0, 0));
   client.add_edge("bedroom", tf_r2l, "leia");
   client.add_edge("bedroom", 0.95, "leia");
 

--- a/bica_graph/CMakeLists.txt
+++ b/bica_graph/CMakeLists.txt
@@ -2,15 +2,16 @@ cmake_minimum_required(VERSION 2.8.3)
 project(bica_graph)
 
 add_compile_options(-std=c++11)
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   roslint
   geometry_msgs
   bica_msgs
-  tf
+  tf2
   tf2_ros
+  tf2_geometry_msgs
   bica_planning
 )
 
@@ -66,6 +67,15 @@ add_dependencies(graph_kms_extractor_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${
 target_link_libraries(graph_kms_extractor_node ${catkin_LIBRARIES} ${PROJECT_NAME} )
 
 
+add_executable(test_publisher_node test/test_publisher_node.cpp)
+add_dependencies(test_publisher_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(test_publisher_node ${catkin_LIBRARIES} ${PROJECT_NAME} )
+
+add_executable(test_subscriber_node test/test_subscriber_node.cpp)
+add_dependencies(test_subscriber_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(test_subscriber_node ${catkin_LIBRARIES} ${PROJECT_NAME} )
+
+
 install(DIRECTORY include/${PROJECT_NAME}/
    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
    FILES_MATCHING PATTERN "*.h"
@@ -87,11 +97,11 @@ if(CATKIN_ENABLE_TESTING)
 
   add_executable(${PROJECT_NAME}_test test/test_bica_graph.cpp)
   if(TARGET ${PROJECT_NAME}_test)
-    target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME} gtest)
+    target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES} ${PROJECT_NAME} gtest)
   endif()
   add_executable(${PROJECT_NAME}_test_clientserver test/test_bica_graph_clientserver.cpp)
   if(TARGET ${PROJECT_NAME}_test_clientserver)
-    target_link_libraries(${PROJECT_NAME}_test_clientserver ${PROJECT_NAME} gtest)
+    target_link_libraries(${PROJECT_NAME}_test_clientserver ${catkin_LIBRARIES} ${PROJECT_NAME} gtest)
   endif()
 
   add_rostest(test/test_bica_graph.test)

--- a/bica_graph/include/bica_graph/edge.h
+++ b/bica_graph/include/bica_graph/edge.h
@@ -43,9 +43,14 @@
 
 #include "bica_graph/macros.h"
 #include "bica_graph/Singleton.h"
-#include <tf/transform_listener.h>
-#include <tf/transform_broadcaster.h>
+
+#include <tf2/LinearMath/Transform.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2/convert.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
 #include <geometry_msgs/TransformStamped.h>
 
 
@@ -93,14 +98,15 @@ private:
   double data_;
 };
 
-class BicaTransformListener: public Singleton<tf::TransformListener> {};
-class BicaTransformBroadcaster: public Singleton<tf::TransformBroadcaster> {};
+
+class BicaTransformBuffer: public Singleton<tf2_ros::Buffer> {};
+class BicaTransformBroadcaster: public Singleton<tf2_ros::TransformBroadcaster> {};
 class BicaStaticTransformBroadcaster: public Singleton<tf2_ros::StaticTransformBroadcaster> {};
 
 class TFEdge
 {
 public:
-  TFEdge(const std::string& source, const tf::Transform& data, const std::string& target, bool static_tf = false);
+  TFEdge(const std::string& source, const tf2::Transform& data, const std::string& target, bool static_tf = false);
   TFEdge(const std::string& source, const std::string& target, bool static_tf = false);
   TFEdge(const TFEdge& other);
 
@@ -108,18 +114,21 @@ public:
   const std::string get_target() const {return target_;}
   bool is_static() const {return static_tf_;}
 
-  const tf::Transform get() const;
-  void set(const tf::Transform& data);
+  const tf2::Transform get() const;
+  void set(const tf2::Transform& data);
 
   friend bool operator==(const TFEdge& lhs, const TFEdge& rhs);
   friend bool operator!=(const TFEdge& lhs, const TFEdge& rhs);
+
 private:
-  void publish_transform(const std::string& source, const std::string& target, const tf::Transform& data);
+  void publish_transform(const std::string& source, const std::string& target, const tf2::Transform& data);
 
   ros::NodeHandle nh_;
 
-  tf::TransformListener *tf_listener_;
-  tf::TransformBroadcaster *tf_broadcaster_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+
+  tf2_ros::Buffer *tfBuffer;
+  tf2_ros::TransformBroadcaster *tf_broadcaster_;
   tf2_ros::StaticTransformBroadcaster *static_tf_broadcaster_;
 
   std::string source_;

--- a/bica_graph/include/bica_graph/graph.h
+++ b/bica_graph/include/bica_graph/graph.h
@@ -70,7 +70,7 @@ public:
 
   void add_edge(const std::string& source, const std::string& data, const std::string& target);
   void add_edge(const std::string& source, const double data, const std::string& target);
-  void add_edge(const std::string& source, const tf::Transform& data,
+  void add_edge(const std::string& source, const tf2::Transform& data,
     const std::string& target, bool static_tf = false);
   void add_edge(const StringEdge& other);
   void add_edge(const DoubleEdge& other);

--- a/bica_graph/include/bica_graph/graph_client.h
+++ b/bica_graph/include/bica_graph/graph_client.h
@@ -44,8 +44,10 @@
 #include <regex>
 #include <vector>
 
-#include <tf/tf.h>
+#include <tf2/LinearMath/Transform.h>
 #include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2/transform_datatypes.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include "bica_graph/conversions.h"
 #include "bica_graph/exceptions.h"
@@ -61,7 +63,7 @@ class GraphClient
 public:
   GraphClient();
 
-  tf::StampedTransform get_tf(const std::string& node_src, const std::string& node_target);
+  tf2::Stamped<tf2::Transform> get_tf(const std::string& node_src, const std::string& node_target);
   void set_tf_identity(const std::string& frame_id_1, const std::string& frame_id_2);
 
   bool exist_node(const std::string& id) const;
@@ -74,7 +76,7 @@ public:
 
   void add_edge(const std::string& source, const std::string& data, const std::string& target);
   void add_edge(const std::string& source, const double data, const std::string& target);
-  void add_edge(const std::string& source, const tf::Transform& data,
+  void add_edge(const std::string& source, const tf2::Transform& data,
     const std::string& target, bool static_tf = false);
   void add_edge(const StringEdge& other);
   void add_edge(const DoubleEdge& other);
@@ -109,6 +111,8 @@ public:
   std::vector<StringEdge> get_string_edges_from_node_by_data(const std::string& node_src_id, const std::string& expr);
   std::vector<StringEdge> get_string_edges_by_data(const std::string& expr);
 
+
+
   void print();
 private:
   void graph_callback(const bica_msgs::Graph::ConstPtr& msg);
@@ -119,8 +123,10 @@ protected:
   ros::NodeHandle nh_;
   ros::Subscriber graph_sub_;
   ros::ServiceClient update_srv_client_;
+
+  tf2_ros::Buffer tfBuffer;
   tf2_ros::StaticTransformBroadcaster static_tf_broadcaster_;
-  tf::TransformListener tf_listener_;
+  tf2_ros::TransformListener tf_listener_;
 };
 
 }  // namespace bica_graph

--- a/bica_graph/package.xml
+++ b/bica_graph/package.xml
@@ -17,20 +17,24 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>bica_msgs</build_depend>
   <build_depend>bica_planning</build_depend>
-  <build_depend>tf</build_depend>
+  <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_export_depend>bica_planning</build_export_depend>
 
   <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>tf</build_export_depend>
+  <build_export_depend>tf2</build_export_depend>
   <build_export_depend>tf2_ros</build_export_depend>
   <build_export_depend>bica_msgs</build_export_depend>
+  <build_export_depend>tf2_geometry_msgs</build_export_depend>
   <build_export_depend>bica_planning</build_export_depend>
 
   <exec_depend>roscpp</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>bica_msgs</exec_depend>
-  <exec_depend>tf</exec_depend>
+  <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>bica_planning</exec_depend>
 
   <build_depend>roslint</build_depend>

--- a/bica_graph/src/bica_graph/conversions.cpp
+++ b/bica_graph/src/bica_graph/conversions.cpp
@@ -40,10 +40,10 @@
 
 namespace bica_graph
 {
-void node_to_msg(const Node::SharedPtr& node, bica_msgs::Node* msg)
+void node_to_msg(const Node& node, bica_msgs::Node* msg)
 {
-  msg->id = node->get_id();
-  msg->type = node->get_type();
+  msg->id = node.get_id();
+  msg->type = node.get_type();
 }
 
 void msg_to_node(const bica_msgs::Node& msg, Node* node)

--- a/bica_graph/src/bica_graph/graph.cpp
+++ b/bica_graph/src/bica_graph/graph.cpp
@@ -170,7 +170,7 @@ Graph::add_edge(const std::string& source, const double data, const std::string&
 }
 
 void
-Graph::add_edge(const std::string& source, const tf::Transform& data, const std::string& target, bool static_tf)
+Graph::add_edge(const std::string& source, const tf2::Transform& data, const std::string& target, bool static_tf)
 {
   add_edge(TFEdge(source, data, target, static_tf));
 }

--- a/bica_graph/src/graph_kms_extractor_node.cpp
+++ b/bica_graph/src/graph_kms_extractor_node.cpp
@@ -119,7 +119,6 @@ private:
   {
     std::list<std::string> nodes_to_remove;
 
-    std::map<std::string, Node::SharedPtr>::const_iterator it;
     for (auto node : graph_.get_nodes())
     {
       std::string type = node.get_type();

--- a/bica_graph/test/test_bica_graph_clientserver.cpp
+++ b/bica_graph/test/test_bica_graph_clientserver.cpp
@@ -38,6 +38,8 @@
 #include <ros/ros.h>
 #include <gtest/gtest.h>
 
+#include <tf2_ros/transform_listener.h>
+
 #include <string>
 
 #include <bica_graph/graph_client.h>
@@ -66,10 +68,10 @@ TEST(BicaGraph, test_graph_construction)
   auto client_1 = std::make_shared<GraphClientTest>();
   auto client_2 = std::make_shared<GraphClientTest>();
 
-  client_1->add_node("leia", "robot");
+  try { client_1->add_node("leia", "robot"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
 
   ros::Time start = ros::Time::now();
-  while ((ros::Time::now() - start).toSec() < 3.0 ) {}
+  while ((ros::Time::now() - start).toSec() < 2.0 ) {}
 
   ASSERT_EQ(1, client_1->count_nodes());
   ASSERT_EQ(1, client_2->count_nodes());
@@ -77,7 +79,7 @@ TEST(BicaGraph, test_graph_construction)
   start = ros::Time::now();
   while ((ros::Time::now() - start).toSec() < 2.0 ) {}
 
-  client_2->remove_node("leia");
+  try { client_2->remove_node("leia"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
 
   start = ros::Time::now();
   while ((ros::Time::now() - start).toSec() < 2.0 ) {}
@@ -85,81 +87,105 @@ TEST(BicaGraph, test_graph_construction)
   ASSERT_EQ(0, client_1->count_nodes());
   ASSERT_EQ(0, client_2->count_nodes());
 
-  client_1->add_node("leia", "robot");
-  client_1->add_node("bedroom", "room");
-  client_1->add_edge("leia", "is", "bedroom");
+  try { client_1->add_node("leia", "robot"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
+  try { client_1->add_node("bedroom", "room"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
+  try { client_1->add_edge("leia", "is", "bedroom"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
 
   start = ros::Time::now();
-  while ((ros::Time::now() - start).toSec() < 2.0 ) {}
+  while ((ros::Time::now() - start).toSec() < 1.5 ) {}
 
   ASSERT_TRUE(client_2->exist_edge("leia", "is", "bedroom"));
 
-  tf::Transform tf_r2l(tf::Quaternion(0, 0, 0, 1), tf::Vector3(3, 0, 0));
+  tf2::Transform tf_r2l(tf2::Quaternion(0, 0, 0, 1), tf2::Vector3(3, 0, 0));
   client_1->add_edge("bedroom", tf_r2l, "leia");
 
   start = ros::Time::now();
   while ((ros::Time::now() - start).toSec() < 2.0 ) {}
 
   ASSERT_TRUE(client_2->exist_tf_edge("bedroom", "leia"));
-  auto edge_2 = client_2->get_tf_edge("bedroom", "leia");
+  try
+  {
+    auto edge_2 = client_2->get_tf_edge("bedroom", "leia");
+    ASSERT_EQ(tf_r2l, edge_2.get());
+    ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
 
-  ASSERT_EQ(tf_r2l, edge_2.get());
+  try
+  {
+    client_1->add_edge("bedroom", 0.95, "leia");
+    ASSERT_TRUE(true);
+  }
+  catch(std::exception* e)
+  {
+    ROS_ERROR("%s", e->what());
+    ASSERT_TRUE(false);
+  }
 
-  client_1->add_edge("bedroom", 0.95, "leia");
   start = ros::Time::now();
   while ((ros::Time::now() - start).toSec() < 2.0 ) {}
 
   ASSERT_TRUE(client_2->exist_double_edge("bedroom", "leia"));
 
-  auto edge_3 = client_2->get_double_edge("bedroom", "leia");
+  try
+  {
+    auto edge_3 = client_2->get_double_edge("bedroom", "leia");
+    ASSERT_EQ(0.95, edge_3.get());
+    ASSERT_TRUE(true);
+  }
+  catch(...)
+  {
+    ASSERT_TRUE(false);
+  }
 
-  ASSERT_EQ(0.95, edge_3.get());
-
-
-  client_1->remove_double_edge("bedroom", "leia");
-  client_1->remove_tf_edge("bedroom", "leia");
-  client_1->remove_edge("leia", "is", "bedroom");
+  try { client_1->remove_double_edge("bedroom", "leia"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
+  try { client_1->remove_tf_edge("bedroom", "leia"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
+  try { client_1->remove_edge("leia", "is", "bedroom"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
 
   start = ros::Time::now();
   while ((ros::Time::now() - start).toSec() < 2.0 ) {}
 
   spinner.stop();
 }
-/*
+
 TEST(BicaGraph, test_graph_tf)
 {
   ros::Time::init();
   ros::AsyncSpinner spinner(2);
   spinner.start();
-  tf::TransformListener tf_listener;
+  tf2_ros::Buffer tfBuffer;
+  tf2_ros::TransformListener tf_listener(tfBuffer);
 
   auto server = std::make_shared<GraphServerTest>();
   auto client_1 = std::make_shared<GraphClientTest>();
   auto client_2 = std::make_shared<GraphClientTest>();
 
-  client_1->add_node("leia", "robot");
-  client_1->add_node("world", "abstract");
-  client_1->add_node("ball", "object");
+  try { client_1->add_node("leia", "robot"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
+  try { client_1->add_node("world", "abstract"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
+  try { client_1->add_node("ball", "object"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
 
   ros::Time start = ros::Time::now();
-  while ((ros::Time::now() - start).toSec() < 1.0 ) {}
+  while ((ros::Time::now() - start).toSec() < 2.0 ) {}
 
-  client_1->set_tf_identity("base_footprint", "leia");
-  client_1->set_tf_identity("odom", "world");
+  try { client_1->set_tf_identity("base_footprint", "leia"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
+  try { client_1->set_tf_identity("odom", "world"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
 
-  tf::Transform tf_r2b(tf::Quaternion(0, 0, 0, 1), tf::Vector3(3, 0, 0));
-  tf::Transform tf_w2r(tf::Quaternion(0, 0, 0, 1), tf::Vector3(1, 0, 0));
+  tf2::Transform tf_r2b(tf2::Quaternion(0, 0, 0, 1), tf2::Vector3(3, 0, 0));
+  tf2::Transform tf_w2r(tf2::Quaternion(0, 0, 0, 1), tf2::Vector3(1, 0, 0));
 
-  client_1->add_edge("world", tf_w2r, "leia");
-  client_1->add_edge("leia", tf_r2b, "ball");
+  try { client_1->add_edge("world", tf_w2r, "leia"); ASSERT_TRUE(true); } catch(...) { ASSERT_TRUE(false); }
+  try { client_1->add_edge("leia", tf_r2b, "ball"); ASSERT_TRUE(true);}
+  catch(std::exception* e)
+  {
+    ROS_ERROR("%s", e->what());
+    ASSERT_TRUE(false);
+  }
 
   start = ros::Time::now();
   while ((ros::Time::now() - start).toSec() < 3.0 ) {}
 
   try
   {
-    tf::Vector3 v1 = client_1->get_tf("world", "ball").getOrigin();
-    ASSERT_EQ(tf::Vector3(4, 0, 0), v1);
+    tf2::Vector3 v1 = client_1->get_tf("world", "ball").getOrigin();
+    ASSERT_EQ(tf2::Vector3(4, 0, 0), v1);
   }
   catch(bica_graph::exceptions::TransformNotPossible& e)
   {
@@ -167,31 +193,30 @@ TEST(BicaGraph, test_graph_tf)
     ASSERT_TRUE(false);
   }
 
-
-  tf::StampedTransform tf;
-
-  try
+  geometry_msgs::TransformStamped tf;
+  std::string error;
+  if (tfBuffer.canTransform("odom", "ball", ros::Time(0), ros::Duration(0.1), &error))
   {
-    tf_listener.waitForTransform("odom", "ball", ros::Time(0), ros::Duration(1.0));
-    tf_listener.lookupTransform("odom", "ball", ros::Time(0), tf);
-
-    ASSERT_EQ(tf::Vector3(4, 0, 0), tf.getOrigin());
+    tf2::Stamped<tf2::Transform> tf2;
+    tf = tfBuffer.lookupTransform("odom", "ball", ros::Time(0));
+    tf2::fromMsg(tf, tf2);
+    ASSERT_EQ(tf2::Vector3(4, 0, 0), tf2.getOrigin());
   }
-  catch (tf::TransformException& ex)
+  else
   {
-    ROS_ERROR("%s", ex.what());
+    ROS_ERROR("Can't transform %s", error.c_str());
     ASSERT_TRUE(false);
   }
 
   spinner.stop();
-}*/
+}
 
 TEST(BicaGraph, test_advanced_funcs)
 {
+  /*
   ros::Time::init();
   ros::AsyncSpinner spinner(2);
   spinner.start();
-  tf::TransformListener tf_listener;
 
   auto server = std::make_shared<GraphServerTest>();
   auto client = std::make_shared<GraphClientTest>();
@@ -260,7 +285,7 @@ TEST(BicaGraph, test_advanced_funcs)
   ASSERT_EQ(client->get_string_edges_by_data("is_near")[0].get_target(), "table_1");
 
   ASSERT_EQ(client->get_string_edges_by_data("is_near")[2].get_source(), "ball");
-  ASSERT_EQ(client->get_string_edges_by_data("is_near")[2].get_target(), "leia");
+  ASSERT_EQ(client->get_string_edges_by_data("is_near")[2].get_target(), "leia");*/
 }
 
 

--- a/bica_graph/test/test_publisher_node.cpp
+++ b/bica_graph/test/test_publisher_node.cpp
@@ -34,44 +34,47 @@
 
 /* Author: Francisco Martín Rico - fmrico@gmail.com */
 
-#ifndef BICA_GRAPH_NODE_H
-#define BICA_GRAPH_NODE_H
+#include <ros/ros.h>
 
-#include <list>
-#include <memory>
-#include <string>
+#include <bica_graph/graph.h>
+#include <bica_graph/graph_client.h>
 
-
-namespace bica_graph
+int main(int argc, char* argv[])
 {
+  ros::init(argc, argv, "graph_publisher_node");
+  ros::NodeHandle n;
 
-class Node
-{
-public:
-  /// Default constructor.
-  /**
-   * Tipically, a Node is not created throught Graph::add_node
-   * \param[in] id The id of the new node.
-   * \param[in] type The type of the node.
-   */
-  Node(const std::string& id, const std::string& type);
-  Node(const std::string& id);
-  Node(const Node& other);
+  ROS_INFO("Creating graph client...");
+  bica_graph::GraphClient client;
+  ROS_INFO("done");
+  ros::Rate rate(5);
+  ros::Time start = ros::Time::now();
+  while (ros::ok() && (ros::Time::now() - start).toSec() < 2.0 )
+  {
+    ROS_INFO("spinnging 1");
+    ros::spinOnce();
+    rate.sleep();
+  }
 
-  const std::string get_id() const;
-  const std::string get_type() const;
-  void set_id(const std::string& id) {id_ = id;}
-  void set_type(const std::string& type) {type_ = type;}
+  ROS_INFO("adding node 1");
+  client.add_node("leia", "robot");
+  ROS_INFO("adding node 2");
+  client.add_node("bedroom", "room");
+  ROS_INFO("adding edge is");
+  client.add_edge("leia", "is", "bedroom");
 
-  friend bool operator==(const Node& lhs, const Node& rhs);
-  friend bool operator!=(const Node& lhs, const Node& rhs);
+  start = ros::Time::now();
+  while (ros::ok() && (ros::Time::now() - start).toSec() < 200.0 )
+  {
+    ROS_INFO("adding transform spinnging");
 
-protected:
-  std::string type_;
-  std::string id_;
-};
+    tf2::Transform tf_r2l(tf2::Quaternion(0, 0, 0, 1), tf2::Vector3((ros::Time::now() - start).toSec(), 0, 0));
 
+    client.add_edge("bedroom", tf_r2l, "leia");
 
-}  // namespace bica_graph
+    ros::spinOnce();
+    rate.sleep();
+  }
 
-#endif  // BICA_GRAPH_NODE_H
+  return 0;
+}


### PR DESCRIPTION
This PR has a big impact because forces to use TF2 instead of TF when using bica_graph. Mixing TF and TF2 could be the reason for some problem, and static tf are only available in tf2.

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>