### PR TITLE
Remove requirement to C++17 to use official BT

### DIFF
--- a/bica/CMakeLists.txt
+++ b/bica/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(bica)
 
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE DEBUG)
 
 find_package(ament_cmake REQUIRED)

--- a/bica_behavior_tree/CMakeLists.txt
+++ b/bica_behavior_tree/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(bica_behavior_tree)
 
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE DEBUG)
 
 find_package(ament_cmake REQUIRED)

--- a/bica_examples/CMakeLists.txt
+++ b/bica_examples/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(bica_examples)
 
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE DEBUG)
 
 find_package(ament_cmake REQUIRED)

--- a/bica_examples/planning/actions/move_action_node.cpp
+++ b/bica_examples/planning/actions/move_action_node.cpp
@@ -80,7 +80,8 @@ public:
     current_pos_ = msg->pose.pose;
   }
 
-  void onActivate()
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State & previous_state)
   {
     getFeedback()->progress = 0.0;
 
@@ -116,15 +117,20 @@ public:
     navigation_goal_handle_ = future_navigation_goal_handle_.get();
     if (!navigation_goal_handle_) {
       RCLCPP_ERROR(get_logger(), "Goal was rejected by server");
-      return;
+      return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
     }
 
     bica_component_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  void onFinish()
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State & previous_state)
   {
     bica_component_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
 private:

--- a/bica_examples/planning/actions/patrol_action_node.cpp
+++ b/bica_examples/planning/actions/patrol_action_node.cpp
@@ -36,19 +36,24 @@ public:
   }
 
 
-  void onActivate()
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State & previous_state)
   {
-    ActionExecutorClient::onActivate();
     getFeedback()->progress = 0.0;
 
     cmd_vel_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", 10);
 
     bica_component_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  void onFinish()
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State & previous_state)
   {
     bica_component_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
 private:

--- a/bica_examples/planning/bica_patrolling_controller_node.cpp
+++ b/bica_examples/planning/bica_patrolling_controller_node.cpp
@@ -78,7 +78,7 @@ public:
             "{" << feedback.current_action << "} [" << feedback.progress_current_action << "%]" <<
             std::endl;
 
-          if (executor_client_->getResult().has_value()) {
+          if (executor_client_->getResult()) {
             if (executor_client_->getResult().value().success) {
               std::cout << "Successful finished " << std::endl;
 
@@ -108,7 +108,7 @@ public:
             "{" << feedback.current_action << "} [" << feedback.progress_current_action << "%]" <<
             std::endl;
 
-          if (executor_client_->getResult().has_value()) {
+          if (executor_client_->getResult()) {
             if (executor_client_->getResult().value().success) {
               std::cout << "Successful finished " << std::endl;
 
@@ -138,7 +138,7 @@ public:
             "{" << feedback.current_action << "} [" << feedback.progress_current_action << "%]" <<
             std::endl;
 
-          if (executor_client_->getResult().has_value()) {
+          if (executor_client_->getResult()) {
             if (executor_client_->getResult().value().success) {
               std::cout << "Successful finished " << std::endl;
 
@@ -168,7 +168,7 @@ public:
             "{" << feedback.current_action << "} [" << feedback.progress_current_action << "%]" <<
             std::endl;
 
-          if (executor_client_->getResult().has_value()) {
+          if (executor_client_->getResult()) {
             if (executor_client_->getResult().value().success) {
               std::cout << "Successful finished " << std::endl;
 

--- a/bica_graph/CMakeLists.txt
+++ b/bica_graph/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(bica_graph)
 
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE DEBUG)
 
 find_package(ament_cmake REQUIRED)
@@ -11,6 +10,8 @@ find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+
+find_package(Boost 1.65.1 REQUIRED)
 
 set(dependencies
     rclcpp

--- a/bica_graph/include/bica_graph/Graph.hpp
+++ b/bica_graph/include/bica_graph/Graph.hpp
@@ -15,6 +15,8 @@
 #ifndef BICA_GRAPH__GRAPH_HPP_
 #define BICA_GRAPH__GRAPH_HPP_
 
+#include <boost/optional.hpp>
+
 #include <vector>
 #include <map>
 #include <string>
@@ -36,13 +38,13 @@ public:
   bool add_node(const Node & node);
   bool remove_node(const std::string node);
   bool exist_node(const std::string node);
-  std::optional<Node> get_node(const std::string node);
+  boost::optional<Node> get_node(const std::string node);
 
   bool add_edge(const Edge & edge);
   bool remove_edge(const Edge & edge);
   bool exist_edge(const Edge & edge);
 
-  std::optional<std::vector<Edge> *> get_edges(
+  boost::optional<std::vector<Edge> *> get_edges(
     const std::string & source,
     const std::string & target);
 

--- a/bica_graph/include/bica_graph/GraphInterface.hpp
+++ b/bica_graph/include/bica_graph/GraphInterface.hpp
@@ -15,6 +15,8 @@
 #ifndef BICA_GRAPH__GRAPHINTERFACE_HPP_
 #define BICA_GRAPH__GRAPHINTERFACE_HPP_
 
+#include <boost/optional.hpp>
+
 #include <vector>
 #include <map>
 #include <string>
@@ -33,7 +35,7 @@ public:
   virtual bool add_node(const Node & node) = 0;
   virtual bool remove_node(const std::string node) = 0;
   virtual bool exist_node(const std::string node) = 0;
-  virtual std::optional<Node> get_node(const std::string node) = 0;
+  virtual boost::optional<Node> get_node(const std::string node) = 0;
 
   virtual bool add_edge(const Edge & edge) = 0;
   virtual bool remove_edge(const Edge & edge) = 0;
@@ -42,7 +44,7 @@ public:
   virtual const std::map<ConnectionT, std::vector<Edge>> & get_edges() = 0;
   virtual const std::map<std::string, Node> & get_nodes() = 0;
 
-  virtual std::optional<std::vector<Edge> *> get_edges(
+  virtual boost::optional<std::vector<Edge> *> get_edges(
     const std::string & source,
     const std::string & target) = 0;
 

--- a/bica_graph/include/bica_graph/GraphNode.hpp
+++ b/bica_graph/include/bica_graph/GraphNode.hpp
@@ -15,6 +15,8 @@
 #ifndef BICA_GRAPH__GRAPHNODE_HPP_
 #define BICA_GRAPH__GRAPHNODE_HPP_
 
+#include <boost/optional.hpp>
+
 #include <vector>
 #include <map>
 #include <string>
@@ -41,7 +43,7 @@ public:
   bool add_node(const Node & node);
   bool remove_node(const std::string node);
   bool exist_node(const std::string node);
-  std::optional<Node> get_node(const std::string node);
+  boost::optional<Node> get_node(const std::string node);
 
   bool add_edge(const Edge & edge);
   bool remove_edge(const Edge & edge);
@@ -50,7 +52,7 @@ public:
   const std::map<std::string, Node> & get_nodes();
   const std::map<ConnectionT, std::vector<Edge>> & get_edges();
 
-  std::optional<std::vector<Edge> *> get_edges(
+  boost::optional<std::vector<Edge> *> get_edges(
     const std::string & source,
     const std::string & target);
 

--- a/bica_graph/include/bica_graph/TypedGraphNode.hpp
+++ b/bica_graph/include/bica_graph/TypedGraphNode.hpp
@@ -15,6 +15,8 @@
 #ifndef BICA_GRAPH__TYPEDGRAPHNODE_HPP_
 #define BICA_GRAPH__TYPEDGRAPHNODE_HPP_
 
+#include <boost/optional.hpp>
+
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
@@ -39,7 +41,7 @@ public:
   explicit TypedGraphNode(const std::string & provided_node_name);
 
   bool add_tf_edge(TFEdge & tfedge, bool static_tf = false);
-  std::optional<TFEdge> get_tf_edge(const std::string & source, const std::string & target);
+  boost::optional<TFEdge> get_tf_edge(const std::string & source, const std::string & target);
   void set_tf_identity(const std::string & frame_id_1, const std::string & frame_id_2);
 
 private:

--- a/bica_graph/package.xml
+++ b/bica_graph/package.xml
@@ -12,6 +12,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libboost-program-options-dev</build_depend>
+
   <depend>rclcpp</depend>
   <depend>bica_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/bica_graph/src/bica_graph/Graph.cpp
+++ b/bica_graph/src/bica_graph/Graph.cpp
@@ -69,7 +69,7 @@ Graph::exist_node(const std::string node)
   return nodes_.find(node) != nodes_.end();
 }
 
-std::optional<Node>
+boost::optional<Node>
 Graph::get_node(const std::string node)
 {
   if (exist_node(node)) {
@@ -123,14 +123,14 @@ Graph::exist_edge(const Edge & edge)
 
   auto edges = get_edges(edge.source, edge.target);
 
-  if (edges.has_value()) {
+  if (edges) {
     return std::find(edges.value()->begin(), edges.value()->end(), edge) != edges.value()->end();
   } else {
     return false;
   }
 }
 
-std::optional<std::vector<Edge> *>
+boost::optional<std::vector<Edge> *>
 Graph::get_edges(const std::string & source, const std::string & target)
 {
   ConnectionT connection {source, target};

--- a/bica_graph/src/bica_graph/GraphNode.cpp
+++ b/bica_graph/src/bica_graph/GraphNode.cpp
@@ -200,7 +200,7 @@ GraphNode::exist_node(const std::string node)
   return graph_.exist_node(node);
 }
 
-std::optional<Node>
+boost::optional<Node>
 GraphNode::get_node(const std::string node)
 {
   rclcpp::spin_some(node_);
@@ -260,7 +260,7 @@ GraphNode::exist_edge(const Edge & edge)
   return graph_.exist_edge(edge);
 }
 
-std::optional<std::vector<Edge> *>
+boost::optional<std::vector<Edge> *>
 GraphNode::get_edges(const std::string & source, const std::string & target)
 {
   rclcpp::spin_some(node_);

--- a/bica_graph/src/bica_graph/TypedGraphNode.cpp
+++ b/bica_graph/src/bica_graph/TypedGraphNode.cpp
@@ -75,7 +75,7 @@ TypedGraphNode::add_tf_edge(TFEdge & tfedge, bool static_tf)
 
   bool already_exist = false;
   auto previous_edges = get_edges(edge.source, edge.target);
-  if (previous_edges.has_value()) {
+  if (previous_edges) {
     auto it = previous_edges.value()->begin();
     while (!already_exist && it != previous_edges.value()->end()) {
       if (it->type == "tf") {
@@ -103,7 +103,7 @@ TypedGraphNode::add_tf_edge(TFEdge & tfedge, bool static_tf)
   }
 }
 
-std::optional<TFEdge>
+boost::optional<TFEdge>
 TypedGraphNode::get_tf_edge(const std::string & source, const std::string & target)
 {
   if (tfBuffer_ == nullptr) {

--- a/bica_graph/src/graph_terminal.cpp
+++ b/bica_graph/src/graph_terminal.cpp
@@ -87,7 +87,7 @@ public:
         } else {
           auto tf_edge = graph_->get_tf_edge(edge.source, edge.target);
 
-          if (tf_edge.has_value()) {
+          if (tf_edge) {
             tf2::Stamped<tf2::Transform> tf;
             tf2::convert(tf_edge.value().tf_, tf);
 

--- a/bica_graph/test/bica_graph_test.cpp
+++ b/bica_graph/test/bica_graph_test.cpp
@@ -123,13 +123,13 @@ TEST(bica_graph, typedgraph_node_operations)
   ASSERT_TRUE(graph_1.add_tf_edge(tf_edge_1));
 
   auto tf_edge_2 = graph_1.get_tf_edge("kitchen", "r2d2");
-  ASSERT_TRUE(tf_edge_2.has_value());
+  ASSERT_TRUE(tf_edge_2);
   tf2::Stamped<tf2::Transform> tf2;
   tf2::convert(tf_edge_2.value().tf_, tf2);
   ASSERT_EQ(tf1, tf2);
 
   auto tf_edge_3 = graph_1.get_tf_edge("r2d2", "kitchen");
-  ASSERT_TRUE(tf_edge_3.has_value());
+  ASSERT_TRUE(tf_edge_3);
   tf2::Stamped<tf2::Transform> tf3;
   tf2::convert(tf_edge_3.value().tf_, tf3);
   ASSERT_EQ(tf1, tf3.inverse());
@@ -143,7 +143,7 @@ TEST(bica_graph, typedgraph_node_operations)
   ASSERT_TRUE(graph_1.add_tf_edge(tf_edge_4));
 
   auto tf_edge_5 = graph_1.get_tf_edge("kitchen", "r2d2");
-  ASSERT_TRUE(tf_edge_5.has_value());
+  ASSERT_TRUE(tf_edge_5);
   tf2::Stamped<tf2::Transform> tf5;
   tf2::convert(tf_edge_5.value().tf_, tf5);
   ASSERT_EQ(tf4, tf5);


### PR DESCRIPTION
Hi @jginesclavero @lbajo 

In this PR I have removed the references to C++17 to use the official BT package. I had to use boot::optional instead of std::optional, and change the code slightly to adapt to this API.

I hope you enjoy reviewing this!!!